### PR TITLE
Update to Zig 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .zig_cache/*
+.zig-cache/*
 zig-cache/*
 zig-out/*
 .direnv/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/zigimg"]
-	path = tools/zigimg
-	url = https://github.com/zigimg/zigimg

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ To make a debug build, or
 ```
 zig build --release=safe
 ```
-for a release build. You will need to have installed zig on your computer. This was written with zig 0.12.0, so if the latest verison doesn't work, try that one.
+for a release build. You will need to have installed zig on your computer. This was written with zig 0.14.0, so if the latest verison doesn't work, try that one.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .zig_2048,
+    .version = "1.0.0",
+    .fingerprint = 0x44fa22caf6e1d67,
+    .dependencies = .{
+        .zigimg = .{
+            .url = "git+https://github.com/zigimg/zigimg#31268548fe3276c0e95f318a6c0d2ab10565b58d",
+            .hash = "zigimg-0.1.0-lly-O6N2EABOxke8dqyzCwhtUCAafqP35zC7wsZ4Ddxj",
+        },
+    },
+    .paths = .{""},
+}

--- a/src/gba.zig
+++ b/src/gba.zig
@@ -105,7 +105,7 @@ pub const WaitCnt = packed struct {
     phi_terminal_output: PhiTerminalOutput,
     _unused: u1 = 0,
     prefetch_buffer: bool,
-    game_boy: bool = 0,
+    game_boy: bool = false,
 };
 
 pub const DmaCnt = packed struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,7 @@ const winner_img = @import("winner");
 const loser_img = @import("loser");
 
 pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, size: ?usize) noreturn {
-    @setCold(true);
+    @branchHint(.cold);
     if (builtin.mode == .ReleaseSmall or builtin.mode == .ReleaseFast) {
         while (true) {}
     }
@@ -156,7 +156,7 @@ const score_display = struct {
 const x_offset = gba.screen_width / 2 - 32 * 2;
 const y_offset = gba.screen_height / 2 - 32 * 2;
 
-var rng = std.rand.DefaultPrng.init(0);
+var rng = std.Random.DefaultPrng.init(0);
 var rand = rng.random();
 
 var last_input: gba.Keys = .{};
@@ -368,7 +368,7 @@ fn setupWinOrLose() void {
     }
 }
 
-fn newGame(rng_rand: std.rand.Random) noreturn {
+fn newGame(rng_rand: std.Random) noreturn {
     already_won = false;
     score_display.setScore(0);
     score_display.drawScore() catch unreachable;

--- a/src/tile.zig
+++ b/src/tile.zig
@@ -12,7 +12,7 @@ pub fn valueToTile(value: u32) !u32 {
     return std.math.log2_int(u32, value) - 1;
 }
 
-pub fn addTile(tiles: *[16]?u32, rand: std.rand.Random) void {
+pub fn addTile(tiles: *[16]?u32, rand: std.Random) void {
     const free_idx = blk: while (true) {
         const idx = rand.uintLessThan(usize, tiles.len);
         if (tiles[idx] == null)

--- a/tools/gbaimg.zig
+++ b/tools/gbaimg.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const zigimg = @import("zigimg/zigimg.zig");
+const zigimg = @import("zigimg");
 
 const GBAColor = packed struct {
     r: u5 = 0,
@@ -52,12 +52,14 @@ pub fn main() !void {
     var stream_source = std.io.StreamSource{
         .file = file,
     };
-    var img = try zigimg.png.PNG.readImage(std.heap.c_allocator, &stream_source);
+    var img = try zigimg.formats.png.PNG.readImage(std.heap.c_allocator, &stream_source);
     defer img.deinit(std.heap.c_allocator);
     if (@mod(img.height, 8) != 0 or @mod(img.width, 8) != 0) {
         std.debug.print("Image dimensions aren't valid.\n", .{});
         std.process.exit(1);
     }
+
+    try img.convert(std.heap.c_allocator, .rgba32);
 
     var palette: [16]GBAColor = undefined;
     palette[0] = .{


### PR DESCRIPTION
Uses zigimg/zigimg#233

Removed the Git submodule for `zigimg` in favor of fetching it with the Zig build system

Related Zig release notes: [Creating Artifacts from Existing Modules](https://ziglang.org/download/0.14.0/release-notes.html#Creating-Artifacts-from-Existing-Modules)